### PR TITLE
Day3の実装例（全部乗せ）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,17 @@
       "name": "react-and-typescript-study",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.8.3",
+        "dayjs": "^1.11.4",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-redux": "^8.0.2",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
+        "@types/uuid": "^8.3.4",
         "@vitejs/plugin-react": "^2.0.0",
         "typescript": "^4.6.4",
         "vite": "^3.0.0"
@@ -376,6 +381,17 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
@@ -471,17 +487,47 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.3.tgz",
+      "integrity": "sha512-lU/LDIfORmjBbyDLaqFN2JB9YmAT1BElET9y0ZszwhSBa5Ef3t6o5CrHupw5J1iOXwd+o92QfQZ8OJpwXvsssg==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
       "version": "18.0.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
       "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -492,7 +538,7 @@
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
       "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -500,7 +546,17 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@vitejs/plugin-react": {
@@ -621,8 +677,12 @@
     "node_modules/csstype": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "dev": true
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
+      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1079,6 +1139,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -1226,6 +1308,49 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-redux": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -1234,6 +1359,32 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -1375,6 +1526,22 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -1676,6 +1843,14 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
+    "@babel/runtime": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
@@ -1753,17 +1928,35 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.3.tgz",
+      "integrity": "sha512-lU/LDIfORmjBbyDLaqFN2JB9YmAT1BElET9y0ZszwhSBa5Ef3t6o5CrHupw5J1iOXwd+o92QfQZ8OJpwXvsssg==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
       "version": "18.0.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
       "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1774,7 +1967,7 @@
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
       "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
       }
@@ -1782,7 +1975,17 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@vitejs/plugin-react": {
@@ -1865,8 +2068,12 @@
     "csstype": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-      "dev": true
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+    },
+    "dayjs": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
+      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
     },
     "debug": {
       "version": "4.3.4",
@@ -2103,6 +2310,26 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
+    },
     "is-core-module": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -2204,11 +2431,53 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "react-redux": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      }
+    },
     "react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -2298,6 +2567,17 @@
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vite": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.8.3",
+    "dayjs": "^1.11.4",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.0.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
+    "@types/uuid": "^8.3.4",
     "@vitejs/plugin-react": "^2.0.0",
     "typescript": "^4.6.4",
     "vite": "^3.0.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,12 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import './App.css'
+import type { FC } from 'react';
+import { TodoContainer } from './features/todos/components/TodoContainer';
 
-function App() {
-  const [count, setCount] = useState(0)
-
+const App: FC = () => {
   return (
-    <div className="App">
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src="/vite.svg" className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://reactjs.org" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+    <div>
+      <TodoContainer />
     </div>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/src/app/hooks.ts
+++ b/src/app/hooks.ts
@@ -1,0 +1,6 @@
+import { useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import todosReducer from '../features/todos/todosSlice';
+
+export const store = configureStore({
+  reducer: {
+    todos: todosReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/features/todos/components/TodoContainer.tsx
+++ b/src/features/todos/components/TodoContainer.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react';
+import { TodoForm } from './TodoForm';
+
+export const TodoContainer: FC = () => {
+  return (
+    <div>
+      <TodoForm />
+    </div>
+  );
+};

--- a/src/features/todos/components/TodoContainer.tsx
+++ b/src/features/todos/components/TodoContainer.tsx
@@ -1,10 +1,13 @@
 import type { FC } from 'react';
 import { TodoForm } from './TodoForm';
+import { TodoList } from './TodoList';
 
 export const TodoContainer: FC = () => {
   return (
     <div>
       <TodoForm />
+      <hr />
+      <TodoList />
     </div>
   );
 };

--- a/src/features/todos/components/TodoContainer.tsx
+++ b/src/features/todos/components/TodoContainer.tsx
@@ -1,13 +1,22 @@
 import type { FC } from 'react';
+import { useAppSelector } from '../../../app/hooks';
+import { selectTodos, selectDeletedTodos } from '../todosSlice';
 import { TodoForm } from './TodoForm';
 import { TodoList } from './TodoList';
 
 export const TodoContainer: FC = () => {
+  const todos = useAppSelector(selectTodos);
+  const deletedTodos = useAppSelector(selectDeletedTodos);
+
   return (
     <div>
       <TodoForm />
       <hr />
-      <TodoList />
+      <h2>Todo一覧</h2>
+      <TodoList todos={todos} />
+      <hr />
+      <h2>削除されたTodo一覧</h2>
+      <TodoList todos={deletedTodos} />
     </div>
   );
 };

--- a/src/features/todos/components/TodoForm.tsx
+++ b/src/features/todos/components/TodoForm.tsx
@@ -1,0 +1,72 @@
+import { useState, FC } from 'react';
+import type { TodoInput } from '../types';
+import { useAppDispatch } from '../../../app/hooks';
+import { create } from '../todosSlice';
+
+export const TodoForm: FC = () => {
+  const [todoInput, setTodoInput] = useState<TodoInput>({
+    title: '',
+    body: '',
+  });
+
+  const dispatch = useAppDispatch();
+
+  const onChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    setTodoInput({
+      ...todoInput,
+      [event.target.name]: event.target.value,
+    });
+  };
+
+  const onSubmitHandler: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    try {
+      dispatch(create(todoInput));
+      setTodoInput({
+        title: '',
+        body: '',
+      });
+      // input:textにあたっているフォーカスを解除
+      // エンターキーでTodoを追加したときの対処
+      const activeElement = document.activeElement;
+      if (!activeElement) return;
+      (activeElement as HTMLInputElement).blur();
+    } catch (error) {
+      alert(error);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmitHandler} method="post">
+      <div>
+        <label>
+          タイトル :{' '}
+          <input
+            onChange={onChangeHandler}
+            type="text"
+            name="title"
+            value={todoInput.title}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          本文 :{' '}
+          <input
+            onChange={onChangeHandler}
+            type="text"
+            name="body"
+            value={todoInput.body}
+          />
+        </label>
+      </div>
+      <div>
+        <input type="submit" value="作成" />
+      </div>
+    </form>
+  );
+};
+
+export default TodoForm;

--- a/src/features/todos/components/TodoList.tsx
+++ b/src/features/todos/components/TodoList.tsx
@@ -1,0 +1,69 @@
+import type { FC } from 'react';
+import { useAppSelector } from '../../../app/hooks';
+
+export const TodoList: FC = () => {
+  const todos = useAppSelector((state) => state.todos.todos);
+
+  return (
+    <>
+      <table border={1}>
+        <thead>
+          <tr>
+            <th>id</th>
+            <th>タイトル</th>
+            <th>本文</th>
+            <th>ステータス</th>
+            <th>作成日時</th>
+            <th>更新日時</th>
+            <th>削除日時</th>
+            <th>更新ボタン</th>
+            <th>削除ボタン</th>
+          </tr>
+        </thead>
+        <tbody>
+          {todos.length === 0 ? (
+            <tr>
+              <td colSpan={9} style={{ textAlign: 'center' }}>
+                データなし
+              </td>
+            </tr>
+          ) : (
+            todos.map((todo) => {
+              return (
+                <tr key={todo.id}>
+                  <td>{todo.id}</td>
+                  <td>{todo.title}</td>
+                  <td>{todo.body}</td>
+                  <td>{todo.status}</td>
+                  <td>{todo.createdAt}</td>
+                  <td>{todo.updatedAt ?? '無し'}</td>
+                  <td>{todo.deletedAt ?? '無し'}</td>
+                  <td>
+                    <button
+                      onClick={() => {
+                        //TODO: 更新機能の実装
+                      }}
+                    >
+                      更新
+                    </button>
+                  </td>
+                  <td>
+                    <button
+                      onClick={() => {
+                        //TODO: 削除機能の実装
+                      }}
+                    >
+                      削除
+                    </button>
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </>
+  );
+};
+
+export default TodoList;

--- a/src/features/todos/components/TodoList.tsx
+++ b/src/features/todos/components/TodoList.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useAppSelector, useAppDispatch } from '../../../app/hooks';
-import { remove, selectTodos } from '../todosSlice';
+import { remove, update, selectTodos } from '../todosSlice';
 
 export const TodoList: FC = () => {
   const todos = useAppSelector(selectTodos);
@@ -43,7 +43,16 @@ export const TodoList: FC = () => {
                   <td>
                     <button
                       onClick={() => {
-                        //TODO: 更新機能の実装
+                        // ここでは決め打ちでtitleとbodyのみを更新しているが、
+                        // 最終的にはtitle, body, statusに好きな値を入力できるようにする
+                        const updateAction = update({
+                          id: todo.id,
+                          input: {
+                            title: '更新したtitle' + Date.now(),
+                            body: '更新したbody ' + Date.now(),
+                          },
+                        });
+                        dispatch(updateAction);
                       }}
                     >
                       更新

--- a/src/features/todos/components/TodoList.tsx
+++ b/src/features/todos/components/TodoList.tsx
@@ -1,9 +1,13 @@
 import type { FC } from 'react';
-import { useAppSelector, useAppDispatch } from '../../../app/hooks';
-import { remove, update, selectTodos } from '../todosSlice';
+import { useAppDispatch } from '../../../app/hooks';
+import { remove, update, restore } from '../todosSlice';
+import { Todo } from '../types';
 
-export const TodoList: FC = () => {
-  const todos = useAppSelector(selectTodos);
+type Props = {
+  todos: Todo[];
+};
+
+export const TodoList: FC<Props> = ({ todos }) => {
   const dispatch = useAppDispatch();
 
   return (
@@ -59,13 +63,23 @@ export const TodoList: FC = () => {
                     </button>
                   </td>
                   <td>
-                    <button
-                      onClick={() => {
-                        dispatch(remove(todo.id));
-                      }}
-                    >
-                      削除
-                    </button>
+                    {isDeletedTodo(todo) ? (
+                      <button
+                        onClick={() => {
+                          dispatch(restore(todo.id));
+                        }}
+                      >
+                        削除取り消し
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => {
+                          dispatch(remove(todo.id));
+                        }}
+                      >
+                        削除
+                      </button>
+                    )}
                   </td>
                 </tr>
               );
@@ -75,6 +89,10 @@ export const TodoList: FC = () => {
       </table>
     </>
   );
+};
+
+const isDeletedTodo = (todo: Todo) => {
+  return todo.deletedAt !== undefined;
 };
 
 export default TodoList;

--- a/src/features/todos/components/TodoList.tsx
+++ b/src/features/todos/components/TodoList.tsx
@@ -69,7 +69,7 @@ export const TodoList: FC<Props> = ({ todos }) => {
                           dispatch(restore(todo.id));
                         }}
                       >
-                        削除取り消し
+                        復元
                       </button>
                     ) : (
                       <button

--- a/src/features/todos/components/TodoList.tsx
+++ b/src/features/todos/components/TodoList.tsx
@@ -1,8 +1,10 @@
 import type { FC } from 'react';
-import { useAppSelector } from '../../../app/hooks';
+import { useAppSelector, useAppDispatch } from '../../../app/hooks';
+import { remove, selectTodos } from '../todosSlice';
 
 export const TodoList: FC = () => {
-  const todos = useAppSelector((state) => state.todos.todos);
+  const todos = useAppSelector(selectTodos);
+  const dispatch = useAppDispatch();
 
   return (
     <>
@@ -50,7 +52,7 @@ export const TodoList: FC = () => {
                   <td>
                     <button
                       onClick={() => {
-                        //TODO: 削除機能の実装
+                        dispatch(remove(todo.id));
                       }}
                     >
                       削除

--- a/src/features/todos/crud/create.ts
+++ b/src/features/todos/crud/create.ts
@@ -1,0 +1,15 @@
+import type { Todo, TodoInput } from '../types';
+import { v4 as uuidv4 } from 'uuid';
+import { getCurrentDateTime } from '../utils/date';
+
+export const createTodo = (input: TodoInput): Todo => {
+  return {
+    id: input.id ?? uuidv4(),
+    title: input.title,
+    body: input.body,
+    status: input.status ?? 'waiting',
+    createdAt: input.createdAt || getCurrentDateTime(),
+    updatedAt: input.updatedAt,
+    deletedAt: input.deletedAt,
+  };
+};

--- a/src/features/todos/crud/index.ts
+++ b/src/features/todos/crud/index.ts
@@ -1,3 +1,4 @@
 export { createTodo } from './create';
 export { removeTodo } from './remove';
 export { updateTodo } from './update';
+export { restoreTodo } from './restore';

--- a/src/features/todos/crud/index.ts
+++ b/src/features/todos/crud/index.ts
@@ -1,0 +1,2 @@
+export { createTodo } from './create';
+export { removeTodo } from './remove';

--- a/src/features/todos/crud/index.ts
+++ b/src/features/todos/crud/index.ts
@@ -1,2 +1,3 @@
 export { createTodo } from './create';
 export { removeTodo } from './remove';
+export { updateTodo } from './update';

--- a/src/features/todos/crud/remove.ts
+++ b/src/features/todos/crud/remove.ts
@@ -1,0 +1,21 @@
+import type { Todo } from '../types';
+import { getCurrentDateTime } from '../utils/date';
+
+export const removeTodo = ({
+  id,
+  title,
+  body,
+  status,
+  createdAt,
+  updatedAt,
+}: Todo): Todo => {
+  return {
+    id,
+    title,
+    body,
+    status,
+    createdAt,
+    updatedAt,
+    deletedAt: getCurrentDateTime(),
+  };
+};

--- a/src/features/todos/crud/restore.ts
+++ b/src/features/todos/crud/restore.ts
@@ -1,0 +1,8 @@
+import type { Todo } from '../types';
+
+export const restoreTodo = (todo: Todo): Todo => {
+  return {
+    ...todo,
+    deletedAt: undefined,
+  };
+};

--- a/src/features/todos/crud/update.ts
+++ b/src/features/todos/crud/update.ts
@@ -1,0 +1,9 @@
+import type { Todo } from '../types';
+import { getCurrentDateTime } from '../utils/date';
+
+export const updateTodo = (todo: Todo): Todo => {
+  return {
+    ...todo,
+    updatedAt: getCurrentDateTime(),
+  };
+};

--- a/src/features/todos/todosSlice.ts
+++ b/src/features/todos/todosSlice.ts
@@ -1,0 +1,31 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import type { TodoInput, Todo } from './types';
+import { createTodo } from './crud/create';
+
+export type TodoState = {
+  todos: Todo[];
+};
+
+const initialState: TodoState = {
+  todos: [],
+};
+
+export const todoSlice = createSlice({
+  name: 'todos',
+  initialState,
+  reducers: {
+    create: (state, action: PayloadAction<TodoInput>) => {
+      const { title, body } = action.payload;
+      if (!title || !body)
+        throw new Error('タイトルと本文の両方を入力してください');
+
+      const todo = createTodo(action.payload);
+      state.todos.push(todo);
+    },
+  },
+});
+
+export const { create } = todoSlice.actions;
+
+export default todoSlice.reducer;

--- a/src/features/todos/todosSlice.ts
+++ b/src/features/todos/todosSlice.ts
@@ -1,7 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
-import type { TodoInput, Todo } from './types';
-import { createTodo } from './crud/create';
+import type { RootState } from '../../app/store';
+import type { TodoInput, Todo, TodoId } from './types';
+import { createTodo, removeTodo } from './crud';
 
 export type TodoState = {
   todos: Todo[];
@@ -23,9 +24,20 @@ export const todoSlice = createSlice({
       const todo = createTodo(action.payload);
       state.todos.push(todo);
     },
+    remove: (state, action: PayloadAction<TodoId>) => {
+      const id = action.payload;
+      const index = state.todos.findIndex((todo) => todo.id === id);
+      const todo = state.todos[index];
+      if (!todo) return;
+
+      state.todos[index] = removeTodo(todo);
+    },
   },
 });
 
-export const { create } = todoSlice.actions;
+export const { create, remove } = todoSlice.actions;
+
+export const selectTodos = (state: RootState) =>
+  state.todos.todos.filter((todo) => todo.deletedAt === undefined);
 
 export default todoSlice.reducer;

--- a/src/features/todos/todosSlice.ts
+++ b/src/features/todos/todosSlice.ts
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
 import type { TodoInput, Todo, TodoId, TodoUpdatePayload } from './types';
-import { createTodo, removeTodo, updateTodo } from './crud';
+import { createTodo, removeTodo, updateTodo, restoreTodo } from './crud';
 
 export type TodoState = {
   todos: Todo[];
@@ -43,12 +43,23 @@ export const todoSlice = createSlice({
         ...input,
       });
     },
+    restore: (state, action: PayloadAction<TodoId>) => {
+      const id = action.payload;
+      const index = state.todos.findIndex((todo) => todo.id === id);
+      const todo = state.todos[index];
+      if (!todo) return;
+
+      state.todos[index] = restoreTodo(todo);
+    },
   },
 });
 
-export const { create, remove, update } = todoSlice.actions;
+export const { create, remove, update, restore } = todoSlice.actions;
 
 export const selectTodos = (state: RootState) =>
   state.todos.todos.filter((todo) => todo.deletedAt === undefined);
+
+export const selectDeletedTodos = (state: RootState) =>
+  state.todos.todos.filter((todo) => todo.deletedAt !== undefined);
 
 export default todoSlice.reducer;

--- a/src/features/todos/todosSlice.ts
+++ b/src/features/todos/todosSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
-import type { TodoInput, Todo, TodoId } from './types';
-import { createTodo, removeTodo } from './crud';
+import type { TodoInput, Todo, TodoId, TodoUpdatePayload } from './types';
+import { createTodo, removeTodo, updateTodo } from './crud';
 
 export type TodoState = {
   todos: Todo[];
@@ -32,10 +32,21 @@ export const todoSlice = createSlice({
 
       state.todos[index] = removeTodo(todo);
     },
+    update: (state, action: PayloadAction<TodoUpdatePayload>) => {
+      const { id, input } = action.payload;
+      const index = state.todos.findIndex((todo) => todo.id === id);
+      const todo = state.todos[index];
+      if (!todo) return;
+
+      state.todos[index] = updateTodo({
+        ...todo,
+        ...input,
+      });
+    },
   },
 });
 
-export const { create, remove } = todoSlice.actions;
+export const { create, remove, update } = todoSlice.actions;
 
 export const selectTodos = (state: RootState) =>
   state.todos.todos.filter((todo) => todo.deletedAt === undefined);

--- a/src/features/todos/types.ts
+++ b/src/features/todos/types.ts
@@ -1,0 +1,28 @@
+export type TodoId = string;
+export type DateTime = string;
+export const TODO_STATUSES = [
+  'waiting',
+  'working',
+  'pending',
+  'discontinued',
+  'completed',
+] as const;
+export type TodoStatus = typeof TODO_STATUSES[number];
+export type TodoInput = {
+  id?: TodoId;
+  title: string;
+  body: string;
+  status?: TodoStatus;
+  createdAt?: DateTime;
+  updatedAt?: DateTime;
+  deletedAt?: DateTime;
+};
+export type Todo = {
+  id: TodoId;
+  title: string;
+  body: string;
+  status: TodoStatus;
+  createdAt: DateTime;
+  updatedAt?: DateTime;
+  deletedAt?: DateTime;
+};

--- a/src/features/todos/types.ts
+++ b/src/features/todos/types.ts
@@ -1,6 +1,6 @@
 export type TodoId = string;
 export type DateTime = string;
-export const TODO_STATUSES = [
+const TODO_STATUSES = [
   'waiting',
   'working',
   'pending',

--- a/src/features/todos/types.ts
+++ b/src/features/todos/types.ts
@@ -1,5 +1,7 @@
 export type TodoId = string;
+
 export type DateTime = string;
+
 const TODO_STATUSES = [
   'waiting',
   'working',
@@ -8,6 +10,7 @@ const TODO_STATUSES = [
   'completed',
 ] as const;
 export type TodoStatus = typeof TODO_STATUSES[number];
+
 export type TodoInput = {
   id?: TodoId;
   title: string;
@@ -17,6 +20,7 @@ export type TodoInput = {
   updatedAt?: DateTime;
   deletedAt?: DateTime;
 };
+
 export type Todo = {
   id: TodoId;
   title: string;
@@ -25,4 +29,9 @@ export type Todo = {
   createdAt: DateTime;
   updatedAt?: DateTime;
   deletedAt?: DateTime;
+};
+
+export type TodoUpdatePayload = {
+  id: TodoId;
+  input: Partial<TodoInput>;
 };

--- a/src/features/todos/utils/date.ts
+++ b/src/features/todos/utils/date.ts
@@ -1,0 +1,7 @@
+import dayjs from 'dayjs';
+
+export type DateTime = string;
+
+export const getCurrentDateTime = (): DateTime => {
+  return dayjs().format('YYYY-MM-DD HH:mm:ss');
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { store } from './app/store';
+import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
+  <Provider store={store}>
     <App />
-  </React.StrictMode>
-)
+  </Provider>
+);


### PR DESCRIPTION
このプルリクは以下のページように作ったサンプルコードです。

[【課題】この章で作った Todo の機能を全て実装する](https://redux-toolkit-seminar-learning-materials.vercel.app/docs/day3/day3-exercise)


Day3で実装してきた各機能の変更差分は以下からも確認できます。

- [day3 「Todoの新規作成機能の実装」の一例 ](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/3)
- [day3 「Todo一覧の表示機能の実装」の一例](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/4)
- [day3 「Todoの削除機能の実装」の一例（論理削除パターン）](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/5)
- [day3 「Todo の更新機能の実装」の一例](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/6)
- [day3 「Todo の復元機能の実装」の一例](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/7)