### PR TITLE
Day4 の実装例（全部乗せ）

### DIFF
--- a/src/features/todos/api/fetch.ts
+++ b/src/features/todos/api/fetch.ts
@@ -1,0 +1,21 @@
+import { Todo } from '../types';
+import { getTodos } from '../localStorage/todosLocalStorage';
+
+type Response = {
+  data: Todo[];
+};
+
+export const fetchTodos = async (): Promise<Response> => {
+  return new Promise((resolve) => {
+    // 今回はローカルストレージからデータを取得しているが、
+    // バックエンドでDBを用意してAPIを通して取得することもできる。
+    // その場合はfetchTodosの呼び出し元は変えず、この関数（fetchTodos）の中身を修正するだけで良い。
+    // （関数のシグネチャさえ決めれば、関数の呼び出す側は、その関数の中身を知る必要はない）
+    //
+    // シグネチャとは
+    // https://e-words.jp/w/%E3%82%B7%E3%82%B0%E3%83%8D%E3%83%81%E3%83%A3.html#:~:text=%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%9F%E3%83%B3%E3%82%B0%E3%81%AE%E5%88%86%E9%87%8E%E3%81%A7%E3%81%AF%E3%80%81%E9%96%A2%E6%95%B0,%E3%82%B7%E3%82%B0%E3%83%8D%E3%83%81%E3%83%A3%E3%81%AB%E3%82%88%E3%81%A3%E3%81%A6%E8%AD%98%E5%88%A5%E3%81%95%E3%82%8C%E3%82%8B%E3%80%82
+    const todos: Todo[] = getTodos();
+
+    setTimeout(() => resolve({ data: todos }), 1000);
+  });
+};

--- a/src/features/todos/components/DisplayStatusSelector.tsx
+++ b/src/features/todos/components/DisplayStatusSelector.tsx
@@ -1,0 +1,32 @@
+import type { FC } from 'react';
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
+import {
+  changeDisplayStatus,
+  DISPLAY_STATUS_MAP,
+  DisplayStatusType,
+} from '../todosSlice';
+
+export const DisplayStatusSelector: FC = () => {
+  const displayStatus = useAppSelector((status) => status.todos.displayStatus);
+  const dispatch = useAppDispatch();
+
+  const onChangeHandler: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
+    const selectedStatus = e.target.value as DisplayStatusType;
+    dispatch(changeDisplayStatus(selectedStatus));
+  };
+
+  return (
+    <div>
+      閲覧フラグ
+      <select value={displayStatus} onChange={onChangeHandler}>
+        {Object.entries(DISPLAY_STATUS_MAP).map(([key, value]) => {
+          return (
+            <option key={key} value={key}>
+              {value}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+};

--- a/src/features/todos/components/TodoContainer.tsx
+++ b/src/features/todos/components/TodoContainer.tsx
@@ -1,17 +1,16 @@
 import { FC, useEffect } from 'react';
 import { useAppSelector, useAppDispatch } from '../../../app/hooks';
 import {
-  selectTodos,
-  selectDeletedTodos,
+  selectTodosByDisplayStatus,
   selectIsFetching,
   fetchTodosAsync,
 } from '../todosSlice';
 import { TodoForm } from './TodoForm';
 import { TodoList } from './TodoList';
+import { DisplayStatusSelector } from './DisplayStatusSelector';
 
 export const TodoContainer: FC = () => {
-  const todos = useAppSelector(selectTodos);
-  const deletedTodos = useAppSelector(selectDeletedTodos);
+  const todos = useAppSelector(selectTodosByDisplayStatus);
   const isFetching = useAppSelector(selectIsFetching);
   const dispatch = useAppDispatch();
 
@@ -25,11 +24,9 @@ export const TodoContainer: FC = () => {
     <div>
       <TodoForm />
       <hr />
+      <DisplayStatusSelector />
       <h2>Todo一覧</h2>
       <TodoList todos={todos} />
-      <hr />
-      <h2>削除されたTodo一覧</h2>
-      <TodoList todos={deletedTodos} />
     </div>
   );
 };

--- a/src/features/todos/components/TodoContainer.tsx
+++ b/src/features/todos/components/TodoContainer.tsx
@@ -1,12 +1,25 @@
-import type { FC } from 'react';
-import { useAppSelector } from '../../../app/hooks';
-import { selectTodos, selectDeletedTodos } from '../todosSlice';
+import { FC, useEffect } from 'react';
+import { useAppSelector, useAppDispatch } from '../../../app/hooks';
+import {
+  selectTodos,
+  selectDeletedTodos,
+  selectIsFetching,
+  fetchTodosAsync,
+} from '../todosSlice';
 import { TodoForm } from './TodoForm';
 import { TodoList } from './TodoList';
 
 export const TodoContainer: FC = () => {
   const todos = useAppSelector(selectTodos);
   const deletedTodos = useAppSelector(selectDeletedTodos);
+  const isFetching = useAppSelector(selectIsFetching);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    dispatch(fetchTodosAsync());
+  }, []);
+
+  if (isFetching) return <div>読み込み中</div>;
 
   return (
     <div>

--- a/src/features/todos/components/TodoList.tsx
+++ b/src/features/todos/components/TodoList.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import { useAppDispatch, useAppSelector } from '../../../app/hooks';
 import { remove, update, restore } from '../todosSlice';
 import { Todo } from '../types';
+import { useConfirmModal } from './modals/ConfirmModal/useConfirmModal';
 
 type Props = {
   todos: Todo[];
@@ -10,10 +11,17 @@ type Props = {
 export const TodoList: FC<Props> = ({ todos }) => {
   const displayStatus = useAppSelector((state) => state.todos.displayStatus);
   const dispatch = useAppDispatch();
+  const {
+    open: openConfirmModal,
+    setMessage,
+    ConfirmModalWrapper,
+  } = useConfirmModal();
+
   const isSelectDeletedStatus = displayStatus === 'deleted';
 
   return (
     <>
+      <ConfirmModalWrapper />
       <table border={1}>
         <thead>
           <tr>
@@ -69,7 +77,8 @@ export const TodoList: FC<Props> = ({ todos }) => {
                     {isSelectDeletedStatus ? (
                       <button
                         onClick={() => {
-                          dispatch(restore(todo.id));
+                          setMessage('復元しますか？');
+                          openConfirmModal(() => dispatch(restore(todo.id)));
                         }}
                       >
                         復元
@@ -77,7 +86,8 @@ export const TodoList: FC<Props> = ({ todos }) => {
                     ) : (
                       <button
                         onClick={() => {
-                          dispatch(remove(todo.id));
+                          setMessage('本当に削除しますか？');
+                          openConfirmModal(() => dispatch(remove(todo.id)));
                         }}
                       >
                         削除

--- a/src/features/todos/components/TodoList.tsx
+++ b/src/features/todos/components/TodoList.tsx
@@ -3,6 +3,8 @@ import { useAppDispatch, useAppSelector } from '../../../app/hooks';
 import { remove, update, restore } from '../todosSlice';
 import { Todo } from '../types';
 import { useConfirmModal } from './modals/ConfirmModal/useConfirmModal';
+import { useUpdateTodoModal } from './modals/UpdateTodoModal/useUpdateTodoModal';
+import { translateStatus } from '../utils/todoConverter';
 
 type Props = {
   todos: Todo[];
@@ -16,12 +18,18 @@ export const TodoList: FC<Props> = ({ todos }) => {
     setMessage,
     ConfirmModalWrapper,
   } = useConfirmModal();
+  const {
+    open: openUpdateTodoModal,
+    setTodoInput: setTodoInputForUpdateTodoModal,
+    UpdateTodoModalWrapper,
+  } = useUpdateTodoModal();
 
   const isSelectDeletedStatus = displayStatus === 'deleted';
 
   return (
     <>
       <ConfirmModalWrapper />
+      <UpdateTodoModalWrapper />
       <table border={1}>
         <thead>
           <tr>
@@ -50,7 +58,7 @@ export const TodoList: FC<Props> = ({ todos }) => {
                   <td>{todo.id}</td>
                   <td>{todo.title}</td>
                   <td>{todo.body}</td>
-                  <td>{todo.status}</td>
+                  <td>{translateStatus(todo.status)}</td>
                   <td>{todo.createdAt}</td>
                   <td>{todo.updatedAt ?? '無し'}</td>
                   <td>{todo.deletedAt ?? '無し'}</td>
@@ -58,16 +66,16 @@ export const TodoList: FC<Props> = ({ todos }) => {
                     <button
                       disabled={isSelectDeletedStatus}
                       onClick={() => {
-                        // ここでは決め打ちでtitleとbodyのみを更新しているが、
-                        // 最終的にはtitle, body, statusに好きな値を入力できるようにする
-                        const updateAction = update({
-                          id: todo.id,
-                          input: {
-                            title: '更新したtitle' + Date.now(),
-                            body: '更新したbody ' + Date.now(),
-                          },
+                        setTodoInputForUpdateTodoModal(todo);
+                        openUpdateTodoModal((newTodoInput) => {
+                          const updateAction = update({
+                            id: todo.id,
+                            input: {
+                              ...newTodoInput,
+                            },
+                          });
+                          dispatch(updateAction);
                         });
-                        dispatch(updateAction);
                       }}
                     >
                       更新

--- a/src/features/todos/components/TodoList.tsx
+++ b/src/features/todos/components/TodoList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useAppDispatch } from '../../../app/hooks';
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
 import { remove, update, restore } from '../todosSlice';
 import { Todo } from '../types';
 
@@ -8,7 +8,9 @@ type Props = {
 };
 
 export const TodoList: FC<Props> = ({ todos }) => {
+  const displayStatus = useAppSelector((state) => state.todos.displayStatus);
   const dispatch = useAppDispatch();
+  const isSelectDeletedStatus = displayStatus === 'deleted';
 
   return (
     <>
@@ -23,7 +25,7 @@ export const TodoList: FC<Props> = ({ todos }) => {
             <th>更新日時</th>
             <th>削除日時</th>
             <th>更新ボタン</th>
-            <th>削除ボタン</th>
+            <th>{isSelectDeletedStatus ? '復元ボタン' : '削除ボタン'}</th>
           </tr>
         </thead>
         <tbody>
@@ -46,6 +48,7 @@ export const TodoList: FC<Props> = ({ todos }) => {
                   <td>{todo.deletedAt ?? '無し'}</td>
                   <td>
                     <button
+                      disabled={isSelectDeletedStatus}
                       onClick={() => {
                         // ここでは決め打ちでtitleとbodyのみを更新しているが、
                         // 最終的にはtitle, body, statusに好きな値を入力できるようにする
@@ -63,7 +66,7 @@ export const TodoList: FC<Props> = ({ todos }) => {
                     </button>
                   </td>
                   <td>
-                    {isDeletedTodo(todo) ? (
+                    {isSelectDeletedStatus ? (
                       <button
                         onClick={() => {
                           dispatch(restore(todo.id));
@@ -89,10 +92,6 @@ export const TodoList: FC<Props> = ({ todos }) => {
       </table>
     </>
   );
-};
-
-const isDeletedTodo = (todo: Todo) => {
-  return todo.deletedAt !== undefined;
 };
 
 export default TodoList;

--- a/src/features/todos/components/modals/BaseModal/index.module.css
+++ b/src/features/todos/components/modals/BaseModal/index.module.css
@@ -1,0 +1,35 @@
+.modal {
+  width: 100vw;
+  height: 100vh;
+  background-color: #00000077;
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  animation:fadein 0.3s;
+}
+
+@keyframes fadein {
+	from {
+		opacity:0;
+	}
+	to {
+		opacity:1;
+	}
+}
+
+.modalContainer {
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: fit-content;
+  word-break: break-all;
+  min-width: 40vw;
+  max-width: 50vw;
+  padding: 24px;
+  border-radius: 8px;
+}

--- a/src/features/todos/components/modals/BaseModal/index.tsx
+++ b/src/features/todos/components/modals/BaseModal/index.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react';
+import styles from './index.module.css';
+
+type Props = {
+  // React18からchildrenを使う場合は明示する必要がある（以前はFCの中にchildrenが含まれていたため明示する必要はなかった）
+  // https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions
+  children: React.ReactNode;
+  isOpen: boolean;
+};
+
+export const BaseModal: FC<Props> = ({ children, isOpen }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles.modal}>
+      <div className={styles.modalContainer}>{children}</div>
+    </div>
+  );
+};

--- a/src/features/todos/components/modals/ConfirmModal/index.module.css
+++ b/src/features/todos/components/modals/ConfirmModal/index.module.css
@@ -1,0 +1,54 @@
+.message {
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.buttonContainer {
+  display: flex;
+  /* justify-content: space-evenly; */
+  justify-content: center;
+  gap: 16px;
+  width: 100%;
+}
+
+.button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 0;
+  border-radius: 4px;
+  display: inline-block;
+  padding: 8px 16px;
+  background-color: #f7f7f7;
+  outline: auto;
+  outline-width: 1px;
+  outline-color: #eaeaea;
+  cursor: pointer;
+}
+
+.button:hover {
+  background: #e4e4e4;
+}
+
+.button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #c0c0c0;
+}
+
+.okButton {
+  background: #fd4b4b;
+  color: #fff;
+  font-weight: bold;
+  outline: auto;
+  outline-width: 1px;
+  outline-color: #ff3f3f;
+}
+
+.okButton:hover {
+  background: #e93939;
+}
+
+.okButton:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #d93535;
+}

--- a/src/features/todos/components/modals/ConfirmModal/index.tsx
+++ b/src/features/todos/components/modals/ConfirmModal/index.tsx
@@ -1,0 +1,46 @@
+import { FC } from 'react';
+import { BaseModal } from '../BaseModal';
+import styles from './index.module.css';
+
+type Props = {
+  isOpen: boolean;
+  message?: string;
+  onClickCancel?: () => void;
+  onClickOK: () => void;
+};
+
+export const ConfirmModal: FC<Props> = ({
+  onClickCancel,
+  onClickOK,
+  isOpen,
+  message,
+}) => {
+  return (
+    <BaseModal isOpen={isOpen}>
+      <p className={styles.message}>{message}</p>
+      <div className={styles.buttonContainer}>
+        <button
+          className={`${styles.button}`}
+          onClick={(e) => {
+            (e.target as HTMLInputElement).blur();
+            if (!onClickCancel) return;
+
+            onClickCancel();
+          }}
+        >
+          いいえ
+        </button>
+        <button
+          className={`${styles.button} ${styles.okButton}`}
+          onClick={(e) => {
+            (e.target as HTMLInputElement).blur();
+
+            onClickOK();
+          }}
+        >
+          はい
+        </button>
+      </div>
+    </BaseModal>
+  );
+};

--- a/src/features/todos/components/modals/ConfirmModal/useConfirmModal.tsx
+++ b/src/features/todos/components/modals/ConfirmModal/useConfirmModal.tsx
@@ -1,0 +1,42 @@
+// 参考にしたコード: https://github.com/microcmsio/react-hooks-use-modal/blob/master/src/index.tsx
+import { useState, useCallback } from 'react';
+import { ConfirmModal } from './index';
+
+type OnOKHandlerType = Function | undefined;
+
+export const useConfirmModal = () => {
+  const [message, setMessage] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [onOKHandler, setOnOKHandler] = useState<OnOKHandlerType>();
+
+  const open = useCallback(
+    (callback: OnOKHandlerType) => {
+      setIsOpen(true);
+      setOnOKHandler(() => {
+        return callback;
+      });
+    },
+    [setIsOpen, setOnOKHandler]
+  );
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, [setIsOpen]);
+
+  const ConfirmModalWrapper = useCallback(() => {
+    return (
+      <ConfirmModal
+        isOpen={isOpen}
+        message={message}
+        onClickOK={() => {
+          if (onOKHandler) onOKHandler();
+          close();
+        }}
+        onClickCancel={() => {
+          close();
+        }}
+      />
+    );
+  }, [isOpen, onOKHandler, message]);
+
+  return { isOpen, open, close, setMessage, ConfirmModalWrapper };
+};

--- a/src/features/todos/components/modals/UpdateTodoModal/index.module.css
+++ b/src/features/todos/components/modals/UpdateTodoModal/index.module.css
@@ -1,0 +1,71 @@
+.message {
+  font-weight: bold;
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.formContainer {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.formItem {
+  display: flex;
+  justify-content: space-between;
+}
+
+.formItem label {
+  margin-right: 12px;
+}
+
+.buttonContainer {
+  display: flex;
+  margin-top: 16px;
+  justify-content: center;
+  gap: 16px;
+  width: 100%;
+}
+
+.button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: 0;
+  border-radius: 4px;
+  display: inline-block;
+  padding: 8px 16px;
+  background-color: #f7f7f7;
+  outline: auto;
+  outline-width: 1px;
+  outline-color: #eaeaea;
+  cursor: pointer;
+}
+
+.button:hover {
+  background: #e4e4e4;
+}
+
+.button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #c0c0c0;
+}
+
+.okButton {
+  background: #fd4b4b;
+  color: #fff;
+  font-weight: bold;
+  outline: auto;
+  outline-width: 1px;
+  outline-color: #ff3f3f;
+}
+
+.okButton:hover {
+  background: #e93939;
+}
+
+.okButton:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #d93535;
+}

--- a/src/features/todos/components/modals/UpdateTodoModal/index.tsx
+++ b/src/features/todos/components/modals/UpdateTodoModal/index.tsx
@@ -1,0 +1,108 @@
+import { FC, useState } from 'react';
+import { BaseModal } from '../BaseModal';
+import styles from './index.module.css';
+import { TODO_STATUSES, TodoInput, TodoStatus } from '../../../types';
+import { translateStatus } from '../../../utils/todoConverter';
+
+export type OnOKHandlerType = (newInput: TodoInput) => void;
+
+type Props = {
+  isOpen: boolean;
+  input: TodoInput;
+  onClickCancel?: () => void;
+  onClickOK: OnOKHandlerType;
+};
+
+export const UpdateTodoModal: FC<Props> = ({
+  onClickCancel,
+  onClickOK,
+  isOpen,
+  input,
+}) => {
+  const [newInput, setNewInput] = useState<TodoInput>({
+    id: input.id,
+    title: input.title,
+    body: input.body,
+    status: input.status,
+  });
+
+  const onChangeTextHandler: React.ChangeEventHandler<HTMLInputElement> = (
+    e
+  ) => {
+    setNewInput({
+      ...newInput,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const onChangeSelectHandler: React.ChangeEventHandler<HTMLSelectElement> = (
+    e
+  ) => {
+    const newStatus = e.target.value as TodoStatus;
+    setNewInput({
+      ...newInput,
+      status: newStatus,
+    });
+  };
+
+  return (
+    <BaseModal isOpen={isOpen}>
+      <p className={styles.message}>Todoの更新</p>
+      <div className={styles.formContainer}>
+        <div className={styles.formItem}>
+          <label>タイトル</label>
+          <input
+            type="text"
+            name="title"
+            value={newInput.title}
+            onChange={onChangeTextHandler}
+          />
+        </div>
+        <div className={styles.formItem}>
+          <label>本文</label>
+          <input
+            type="text"
+            name="body"
+            value={newInput.body}
+            onChange={onChangeTextHandler}
+          />
+        </div>
+        <div className={styles.formItem}>
+          <label>ステータス</label>
+          <select value={newInput.status} onChange={onChangeSelectHandler}>
+            {TODO_STATUSES.map((status) => {
+              return (
+                <option key={status} value={status}>
+                  {translateStatus(status)}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      </div>
+      <div className={styles.buttonContainer}>
+        <button
+          className={`${styles.button}`}
+          onClick={(e) => {
+            (e.target as HTMLInputElement).blur();
+            if (!onClickCancel) return;
+
+            onClickCancel();
+          }}
+        >
+          キャンセル
+        </button>
+        <button
+          className={`${styles.button} ${styles.okButton}`}
+          onClick={(e) => {
+            (e.target as HTMLInputElement).blur();
+
+            onClickOK(newInput);
+          }}
+        >
+          更新する
+        </button>
+      </div>
+    </BaseModal>
+  );
+};

--- a/src/features/todos/components/modals/UpdateTodoModal/useUpdateTodoModal.tsx
+++ b/src/features/todos/components/modals/UpdateTodoModal/useUpdateTodoModal.tsx
@@ -1,0 +1,44 @@
+// 参考にしたコード: https://github.com/microcmsio/react-hooks-use-modal/blob/master/src/index.tsx
+import { useState, useCallback } from 'react';
+import { UpdateTodoModal, OnOKHandlerType } from './index';
+import { TodoInput } from '../../../types';
+
+export const useUpdateTodoModal = () => {
+  const [todoInput, setTodoInput] = useState<TodoInput | undefined>();
+  const [isOpen, setIsOpen] = useState(false);
+  const [onOKHandler, setOnOKHandler] = useState<OnOKHandlerType>();
+
+  const open = useCallback(
+    (callback: OnOKHandlerType) => {
+      setIsOpen(true);
+      setOnOKHandler(() => {
+        return callback;
+      });
+    },
+    [setIsOpen, setOnOKHandler]
+  );
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, [setIsOpen]);
+
+  const UpdateTodoModalWrapper = useCallback(() => {
+    // TODO: 何かしらの例外を投げる
+    if (!todoInput) return <></>;
+
+    return (
+      <UpdateTodoModal
+        isOpen={isOpen}
+        input={todoInput}
+        onClickOK={(input: TodoInput) => {
+          if (onOKHandler) onOKHandler(input);
+          close();
+        }}
+        onClickCancel={() => {
+          close();
+        }}
+      />
+    );
+  }, [isOpen, onOKHandler, todoInput]);
+
+  return { isOpen, open, close, setTodoInput, UpdateTodoModalWrapper };
+};

--- a/src/features/todos/localStorage/todosLocalStorage.ts
+++ b/src/features/todos/localStorage/todosLocalStorage.ts
@@ -1,0 +1,16 @@
+import type { Todo } from '../types';
+
+const PREFIX_KEY = 'redux-toolkit-seminar';
+const LOCAL_STORAGE_KEY = `${PREFIX_KEY}:todos`;
+
+export const setTodos = (entities: Todo[]) => {
+  window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(entities));
+};
+
+export const getTodos = (): Todo[] => {
+  const jsonEntities = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (!jsonEntities) return [];
+
+  const entities = JSON.parse(jsonEntities) as Todo[];
+  return entities;
+};

--- a/src/features/todos/localStorage/todosLocalStorage.ts
+++ b/src/features/todos/localStorage/todosLocalStorage.ts
@@ -1,16 +1,23 @@
 import type { Todo } from '../types';
 
+// 仮に、将来的にlocalStorageに保存するデータが増やしたい時のkeyのルール決めを行なっている。
+// ルールは「prefix値:データの種類」
+//
+// 例: 保存したいデータの種類ごとのlocalStorageのkey
+//   - todoデータ    : 'redux-toolkit-seminar:todos'
+//   - userデータ    : 'redux-toolkit-seminar:user'
+//   - settingデータ : 'redux-toolkit-seminar:setting'
 const PREFIX_KEY = 'redux-toolkit-seminar';
 const LOCAL_STORAGE_KEY = `${PREFIX_KEY}:todos`;
 
-export const setTodos = (entities: Todo[]) => {
-  window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(entities));
+export const setTodos = (todos: Todo[]) => {
+  window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(todos));
 };
 
 export const getTodos = (): Todo[] => {
-  const jsonEntities = window.localStorage.getItem(LOCAL_STORAGE_KEY);
-  if (!jsonEntities) return [];
+  const json = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (!json) return [];
 
-  const entities = JSON.parse(jsonEntities) as Todo[];
-  return entities;
+  const todos = JSON.parse(json) as Todo[];
+  return todos;
 };

--- a/src/features/todos/todosSlice.ts
+++ b/src/features/todos/todosSlice.ts
@@ -10,14 +10,23 @@ import { createTodo, removeTodo, updateTodo, restoreTodo } from './crud';
 import { fetchTodos } from './api/fetch';
 import { setTodos } from './localStorage/todosLocalStorage';
 
+export const DISPLAY_STATUS_MAP = {
+  all: '全て（削除済みは除く）',
+  updated: '更新済み（削除済みは除く）',
+  deleted: '削除済み',
+};
+export type DisplayStatusType = keyof typeof DISPLAY_STATUS_MAP;
+
 export type TodoState = {
   todos: Todo[];
+  displayStatus: DisplayStatusType;
   isFetching: boolean;
   error: SerializedError | null;
 };
 
 const initialState: TodoState = {
   todos: [],
+  displayStatus: 'all',
   isFetching: false,
   error: null,
 };
@@ -65,6 +74,9 @@ export const todoSlice = createSlice({
       state.todos[index] = restoreTodo(todo);
       setTodos(state.todos);
     },
+    changeDisplayStatus: (state, action: PayloadAction<DisplayStatusType>) => {
+      state.displayStatus = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -92,13 +104,27 @@ export const fetchTodosAsync = createAsyncThunk<Todo[]>(
   }
 );
 
-export const { create, remove, update, restore } = todoSlice.actions;
+export const { create, remove, update, restore, changeDisplayStatus } =
+  todoSlice.actions;
 
 export const selectTodos = (state: RootState) =>
   state.todos.todos.filter((todo) => todo.deletedAt === undefined);
 
 export const selectDeletedTodos = (state: RootState) =>
   state.todos.todos.filter((todo) => todo.deletedAt !== undefined);
+
+export const selectTodosByDisplayStatus = (state: RootState) => {
+  if (state.todos.displayStatus === 'updated') {
+    return state.todos.todos.filter(
+      (todo) => todo.updatedAt !== undefined && todo.deletedAt === undefined
+    );
+  }
+  if (state.todos.displayStatus === 'deleted') {
+    return selectDeletedTodos(state);
+  }
+
+  return selectTodos(state);
+};
 
 export const selectIsFetching = (state: RootState) => state.todos.isFetching;
 

--- a/src/features/todos/todosSlice.ts
+++ b/src/features/todos/todosSlice.ts
@@ -1,15 +1,25 @@
-import { createSlice } from '@reduxjs/toolkit';
+import {
+  createSlice,
+  createAsyncThunk,
+  SerializedError,
+} from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
 import type { TodoInput, Todo, TodoId, TodoUpdatePayload } from './types';
 import { createTodo, removeTodo, updateTodo, restoreTodo } from './crud';
+import { fetchTodos } from './api/fetch';
+import { setTodos } from './localStorage/todosLocalStorage';
 
 export type TodoState = {
   todos: Todo[];
+  isFetching: boolean;
+  error: SerializedError | null;
 };
 
 const initialState: TodoState = {
   todos: [],
+  isFetching: false,
+  error: null,
 };
 
 export const todoSlice = createSlice({
@@ -23,6 +33,7 @@ export const todoSlice = createSlice({
 
       const todo = createTodo(action.payload);
       state.todos.push(todo);
+      setTodos(state.todos);
     },
     remove: (state, action: PayloadAction<TodoId>) => {
       const id = action.payload;
@@ -31,6 +42,7 @@ export const todoSlice = createSlice({
       if (!todo) return;
 
       state.todos[index] = removeTodo(todo);
+      setTodos(state.todos);
     },
     update: (state, action: PayloadAction<TodoUpdatePayload>) => {
       const { id, input } = action.payload;
@@ -42,6 +54,7 @@ export const todoSlice = createSlice({
         ...todo,
         ...input,
       });
+      setTodos(state.todos);
     },
     restore: (state, action: PayloadAction<TodoId>) => {
       const id = action.payload;
@@ -50,9 +63,34 @@ export const todoSlice = createSlice({
       if (!todo) return;
 
       state.todos[index] = restoreTodo(todo);
+      setTodos(state.todos);
     },
   },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchTodosAsync.pending, (state) => {
+        state.isFetching = true;
+      })
+      .addCase(fetchTodosAsync.fulfilled, (state, action) => {
+        state.isFetching = false;
+        state.error = null;
+        state.todos = action.payload;
+      })
+      .addCase(fetchTodosAsync.rejected, (state, action) => {
+        state.isFetching = false;
+        state.error = action.error;
+      });
+  },
 });
+
+export const fetchTodosAsync = createAsyncThunk<Todo[]>(
+  `${todoSlice.name}/fetch`,
+  async () => {
+    const response = await fetchTodos();
+
+    return response.data;
+  }
+);
 
 export const { create, remove, update, restore } = todoSlice.actions;
 
@@ -61,5 +99,7 @@ export const selectTodos = (state: RootState) =>
 
 export const selectDeletedTodos = (state: RootState) =>
   state.todos.todos.filter((todo) => todo.deletedAt !== undefined);
+
+export const selectIsFetching = (state: RootState) => state.todos.isFetching;
 
 export default todoSlice.reducer;

--- a/src/features/todos/types.ts
+++ b/src/features/todos/types.ts
@@ -2,7 +2,7 @@ export type TodoId = string;
 
 export type DateTime = string;
 
-const TODO_STATUSES = [
+export const TODO_STATUSES = [
   'waiting',
   'working',
   'pending',

--- a/src/features/todos/utils/todoConverter.ts
+++ b/src/features/todos/utils/todoConverter.ts
@@ -1,0 +1,16 @@
+import type { TodoStatus } from '../types';
+
+export const translateStatus = (status: TodoStatus) => {
+  // 日本語以外にも、複数の言語に翻訳したい場合は、以下のようなライブラリを使うことも検討する
+  // https://github.com/i18next/react-i18next
+
+  if (status === 'waiting') return '未着手';
+  if (status === 'working') return '着手中';
+  if (status === 'pending') return '保留中';
+  if (status === 'discontinued') return '中止';
+  if (status === 'completed') return '完了';
+
+  // 将来新しくstatusが追加されて翻訳の追加が追いついていない場合は、
+  // status値をそのまま表示することで対応する。
+  return status;
+};


### PR DESCRIPTION
このプルリクは以下のページように作ったサンプルコードです。

[【課題】この章で作った Todo アプリの内容を全て実装する](https://redux-toolkit-seminar-learning-materials.vercel.app/docs/day4/day4-exercise)


Day4で実装してきた各機能の変更差分は以下からも確認できます。


- [day4 「localStorage を使った、データの保存 & 取得機能を実装する」のサンプルコード](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/9/files)
- [day4 「閲覧フラグを使った、表示切り替え機能」のサンプルコード](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/10/files)
- [day4 「削除ボタン・復元ボタンを押した時の機能を実装する」のサンプルコード](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/11/files)
- [day4 「更新ボタンを押した時の機能を実装する」のサンプルコード](https://github.com/tsuyopon-xyz/redux-toolkit-seminar-excercise-examples/pull/12/files)
